### PR TITLE
Added listener to automatically change Haxfred's name

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,6 +221,12 @@ var client = new irc.Client(config.server, config.nick, {
     channels: config.channels
 });
 
+client.addListener('nick', function (oldnick, newnick, channels, message) {
+	if(oldnick == config.nick) {
+		config.nick = newnick;
+	}
+});
+
 
 client.addListener('pm', function (from, message) {
   client.say(from, "thanks for thinking of me.");


### PR DESCRIPTION
If 2 Haxfred’s get loaded on (or someone else is using the name
Haxfred) and Haxfred turns into Haxfred1 or Haxfred_, then this
listener changes the config.nick to Haxfred’s current nickname, that
way he’ll still respond when spoken to.
